### PR TITLE
Make the function name PEP8 compliant

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,9 +19,9 @@ To use the package, import it in your Python code:
 
 .. code-block:: python
 
-    from docker_secrets import getDocketSecrets
+    from docker_secrets import get_docket_secrets
 
-    secret_value = getDocketSecrets('my_secret')
+    secret_value = get_docket_secrets('my_secret')
 
 Contributing
 ------------

--- a/docker_secrets.py
+++ b/docker_secrets.py
@@ -3,7 +3,7 @@ import json
 
 root = os.path.abspath(os.sep)
 
-def getDocketSecrets(name, secretsPath=os.path.abspath(os.path.join(os.sep, "run", "secrets"))):
+def get_docket_secrets(name, secretsPath=os.path.abspath(os.path.join(os.sep, "run", "secrets"))):
     """This function fetches a docker secret
 
     :param name: the name of the docker secret
@@ -28,3 +28,5 @@ def getDocketSecrets(name, secretsPath=os.path.abspath(os.path.join(os.sep, "run
     with open(secretsFilePath) as f:
         secrets = json.load(f)
     return secrets[name]
+
+getDocketSecrets = get_docket_secrets

--- a/tests/test_docker_secrets.py
+++ b/tests/test_docker_secrets.py
@@ -1,7 +1,7 @@
 import json
 import pytest
 from unittest.mock import patch, mock_open
-from docker_secrets import getDocketSecrets
+from docker_secrets import get_docket_secrets
 
 def test_get_docker_secrets_valid():
     secret_name = "my_secret"
@@ -11,7 +11,7 @@ def test_get_docker_secrets_valid():
 
     with patch("builtins.open", mock_open(read_data=secrets_json)):
         with patch("os.listdir", return_value=["secrets.json"]):
-            result = getDocketSecrets(secret_name)
+            result = get_docket_secrets(secret_name)
             assert result == secret_value
 
 def test_get_docker_secrets_missing_secret():
@@ -22,7 +22,7 @@ def test_get_docker_secrets_missing_secret():
     with patch("builtins.open", mock_open(read_data=secrets_json)):
         with patch("os.listdir", return_value=["secrets.json"]):
             with pytest.raises(KeyError):
-                getDocketSecrets(secret_name)
+                get_docket_secrets(secret_name)
 
 def test_get_docker_secrets_invalid_json():
     invalid_json = "{invalid_json}"
@@ -30,12 +30,12 @@ def test_get_docker_secrets_invalid_json():
     with patch("builtins.open", mock_open(read_data=invalid_json)):
         with patch("os.listdir", return_value=["secrets.json"]):
             with pytest.raises(ValueError):
-                getDocketSecrets("my_secret")
+                get_docket_secrets("my_secret")
 
 def test_get_docker_secrets_io_error():
     with patch("os.listdir", side_effect=IOError):
         with pytest.raises(IOError):
-            getDocketSecrets("my_secret")
+            get_docket_secrets("my_secret")
 
 def test_get_docker_secrets_local_env():
     secret_name = "my_secret"
@@ -44,5 +44,5 @@ def test_get_docker_secrets_local_env():
     secrets_json = json.dumps(secrets)
 
     with patch.dict("os.environ", {"LOCAL_SECRETS": secrets_json}):
-        result = getDocketSecrets(secret_name)
+        result = get_docket_secrets(secret_name)
         assert result == secret_value


### PR DESCRIPTION
Related to #1

Rename the function `getDocketSecrets` to `get_docket_secrets` to make it PEP8 compliant and add an alias for backward compatibility.

* **docker_secrets.py**
  - Rename function `getDocketSecrets` to `get_docket_secrets`.
  - Add alias `getDocketSecrets = get_docket_secrets` at the end of the file.

* **tests/test_docker_secrets.py**
  - Update all references to `getDocketSecrets` to `get_docket_secrets`.

* **README.rst**
  - Update usage example to use `get_docket_secrets` instead of `getDocketSecrets`.

