### PR TITLE
Add functionality to load secrets into environment variables

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,49 @@
+# Python artifacts
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Virtual environments
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# IDE specific files
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# Secrets and local configuration
+secrets/
+.env
+*.pem
+*.key
+*.secret
+credentials.json
+
+# Logs
+*.log
+
+# OS specific files
+.DS_Store
+Thumbs.db

--- a/README.md
+++ b/README.md
@@ -1,0 +1,54 @@
+# Docker Secrets
+
+A simple Python module for managing Docker secrets in containerized applications.
+
+## Features
+
+- Retrieve individual Docker secrets
+- Load all secrets into environment variables
+- Selectively load specific secrets into environment variables
+- Compatible with both JSON files and Docker secrets directories
+
+## Usage
+
+### Basic Usage
+
+```python
+from docker_secrets import get_docker_secrets
+
+# Get a single secret
+api_key = get_docker_secrets("api_key")
+print(f"API Key: {api_key}")
+
+# Load all secrets into environment variables
+from docker_secrets import load_all_secrets
+load_all_secrets()
+
+# Load only specific secrets
+from docker_secrets import load_selective_secrets
+load_selective_secrets(["api_key", "database_password"])
+```
+
+### Custom Secrets Path
+
+By default, the module looks for secrets in `/run/secrets` (Docker's default location), but you can specify a custom path:
+
+```python
+# Specify a custom directory
+api_key = get_docker_secrets("api_key", secrets_path="/path/to/secrets")
+
+# Or a specific JSON file
+load_all_secrets(secrets_path="/path/to/secrets.json")
+```
+
+## Testing
+
+Run the tests using:
+
+```
+python -m unittest test_docker_secrets.py
+```
+
+## License
+
+This project is available under the MIT License.

--- a/README.rst
+++ b/README.rst
@@ -19,9 +19,15 @@ To use the package, import it in your Python code:
 
 .. code-block:: python
 
-    from docker_secrets import get_docket_secrets
+    from docker_secrets import get_docket_secrets, load_all_secrets, load_selective_secrets
 
     secret_value = get_docket_secrets('my_secret')
+
+    # Load all secrets into environment variables
+    load_all_secrets()
+
+    # Load selective secrets into environment variables
+    load_selective_secrets(['my_secret', 'another_secret'])
 
 Contributing
 ------------

--- a/docker_secrets.py
+++ b/docker_secrets.py
@@ -1,78 +1,95 @@
 import os
 import json
-from typing import List, Dict
 
 root = os.path.abspath(os.sep)
 
-def get_docket_secrets(name: str, secretsPath: str = os.path.abspath(os.path.join(os.sep, "run", "secrets"))) -> str:
+
+def _get_secrets_file(
+    secrets_path: str = os.path.abspath(os.path.join(os.sep, "run", "secrets")),
+) -> dict[str, str]:
+    """This function reads and returns the secrets from a file or directory
+    
+    :param secrets_path: path to either a json file with secrets or a directory containing secret files
+    :returns: dictionary of secrets
+    :raises IOError: if secrets_path cannot be accessed
+    :raises ValueError: if the secrets JSON cannot be parsed
+    """
+    try:
+        if os.path.isdir(secrets_path):
+            list_of_files = os.listdir(secrets_path)
+            if not list_of_files:
+                raise IOError(f"No secret files found in directory: {secrets_path}")
+            secrets_file = list_of_files[0]
+            secrets_file_path = os.path.join(secrets_path, secrets_file)
+        else:
+            secrets_file_path = secrets_path
+            
+        with open(secrets_file_path) as f:
+            secrets = json.load(f)
+            
+        return secrets
+    except json.JSONDecodeError as e:
+        raise ValueError(f"Failed to parse secrets JSON: {str(e)}")
+    except IOError as e:
+        raise IOError(f"Failed to read secrets file: {str(e)}")
+
+
+def get_docker_secrets(
+    name: str,
+    secrets_path: str | None = None,
+) -> str:
     """This function fetches a docker secret
 
     :param name: the name of the docker secret
-    :param secretsPath: the directory where the secrets are stored
-    :returns: docker secret
+    :param secrets_path: the directory where the secrets are stored (defaults to /run/secrets)
+    :returns: docker secret value
     :raises ValueError: if the secrets cannot be parsed
-    :raises IOError: if [secretsPath] cannot be opened
-    :raises KeyError: if [name] nof found in the secrets
-
-    To load the secrets from the local machine, set the environment variable LOCAL_SECRETS to a json object
-    with open('../secrets', 'r') as file:
-        os.environ["LOCAL_SECRETS"] = file.read()
+    :raises IOError: if [secrets_path] cannot be opened
+    :raises KeyError: if [name] not found in the secrets
     """
 
-    if os.getenv('LOCAL_SECRETS'):
-        secrets = json.loads(os.getenv('LOCAL_SECRETS'))
-        return secrets[name]
-
-    secretsFile = os.listdir(secretsPath)[0]
-    secretsFilePath = os.path.join(secretsPath, secretsFile)
-
-    with open(secretsFilePath) as f:
-        secrets = json.load(f)
+    secrets = _get_secrets_file(secrets_path)
+    if name not in secrets:
+        raise KeyError(f"Secret '{name}' not found in secrets file")
     return secrets[name]
 
-def load_all_secrets(secretsPath: str = os.path.abspath(os.path.join(os.sep, "run", "secrets"))) -> None:
+
+def load_all_secrets(
+    secrets_path: str = os.path.abspath(os.path.join(os.sep, "run", "secrets")),
+) -> None:
     """This function loads all docker secrets into environment variables
 
-    :param secretsPath: the directory where the secrets are stored
+    :param secrets_path: the directory where the secrets are stored
     :raises ValueError: if the secrets cannot be parsed
-    :raises IOError: if [secretsPath] cannot be opened
+    :raises IOError: if [secrets_path] cannot be opened
     """
 
-    if os.getenv('LOCAL_SECRETS'):
-        secrets = json.loads(os.getenv('LOCAL_SECRETS'))
-    else:
-        secretsFile = os.listdir(secretsPath)[0]
-        secretsFilePath = os.path.join(secretsPath, secretsFile)
-
-        with open(secretsFilePath) as f:
-            secrets = json.load(f)
-
+    secrets = _get_secrets_file(secrets_path)
     for key, value in secrets.items():
-        os.environ[key] = value
+        os.environ[key] = str(value)
 
-def load_selective_secrets(names: List[str], secretsPath: str = os.path.abspath(os.path.join(os.sep, "run", "secrets"))) -> None:
+
+def load_selective_secrets(
+    names: list[str],
+    secrets_path: str = os.path.abspath(os.path.join(os.sep, "run", "secrets")),
+) -> None:
     """This function loads selective docker secrets into environment variables
 
     :param names: the names of the docker secrets to load
-    :param secretsPath: the directory where the secrets are stored
+    :param secrets_path: the directory where the secrets are stored
     :raises ValueError: if the secrets cannot be parsed
-    :raises IOError: if [secretsPath] cannot be opened
+    :raises IOError: if [secrets_path] cannot be opened
     :raises KeyError: if any of the [names] not found in the secrets
     """
 
-    if os.getenv('LOCAL_SECRETS'):
-        secrets = json.loads(os.getenv('LOCAL_SECRETS'))
-    else:
-        secretsFile = os.listdir(secretsPath)[0]
-        secretsFilePath = os.path.join(secretsPath, secretsFile)
-
-        with open(secretsFilePath) as f:
-            secrets = json.load(f)
-
+    secrets = _get_secrets_file(secrets_path)
+    missing_secrets = [name for name in names if name not in secrets]
+    if missing_secrets:
+        raise KeyError(f"Secrets not found: {', '.join(missing_secrets)}")
+        
     for name in names:
-        if name in secrets:
-            os.environ[name] = secrets[name]
-        else:
-            raise KeyError(f"Secret {name} not found")
+        os.environ[name] = str(secrets[name])
 
-getDocketSecrets = get_docket_secrets
+
+# Aliases for backward compatibility
+getDockerSecrets = get_docker_secrets

--- a/docker_secrets.py
+++ b/docker_secrets.py
@@ -1,9 +1,10 @@
 import os
 import json
+from typing import List, Dict
 
 root = os.path.abspath(os.sep)
 
-def get_docket_secrets(name, secretsPath=os.path.abspath(os.path.join(os.sep, "run", "secrets"))):
+def get_docket_secrets(name: str, secretsPath: str = os.path.abspath(os.path.join(os.sep, "run", "secrets"))) -> str:
     """This function fetches a docker secret
 
     :param name: the name of the docker secret
@@ -28,5 +29,50 @@ def get_docket_secrets(name, secretsPath=os.path.abspath(os.path.join(os.sep, "r
     with open(secretsFilePath) as f:
         secrets = json.load(f)
     return secrets[name]
+
+def load_all_secrets(secretsPath: str = os.path.abspath(os.path.join(os.sep, "run", "secrets"))) -> None:
+    """This function loads all docker secrets into environment variables
+
+    :param secretsPath: the directory where the secrets are stored
+    :raises ValueError: if the secrets cannot be parsed
+    :raises IOError: if [secretsPath] cannot be opened
+    """
+
+    if os.getenv('LOCAL_SECRETS'):
+        secrets = json.loads(os.getenv('LOCAL_SECRETS'))
+    else:
+        secretsFile = os.listdir(secretsPath)[0]
+        secretsFilePath = os.path.join(secretsPath, secretsFile)
+
+        with open(secretsFilePath) as f:
+            secrets = json.load(f)
+
+    for key, value in secrets.items():
+        os.environ[key] = value
+
+def load_selective_secrets(names: List[str], secretsPath: str = os.path.abspath(os.path.join(os.sep, "run", "secrets"))) -> None:
+    """This function loads selective docker secrets into environment variables
+
+    :param names: the names of the docker secrets to load
+    :param secretsPath: the directory where the secrets are stored
+    :raises ValueError: if the secrets cannot be parsed
+    :raises IOError: if [secretsPath] cannot be opened
+    :raises KeyError: if any of the [names] not found in the secrets
+    """
+
+    if os.getenv('LOCAL_SECRETS'):
+        secrets = json.loads(os.getenv('LOCAL_SECRETS'))
+    else:
+        secretsFile = os.listdir(secretsPath)[0]
+        secretsFilePath = os.path.join(secretsPath, secretsFile)
+
+        with open(secretsFilePath) as f:
+            secrets = json.load(f)
+
+    for name in names:
+        if name in secrets:
+            os.environ[name] = secrets[name]
+        else:
+            raise KeyError(f"Secret {name} not found")
 
 getDocketSecrets = get_docket_secrets

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dockersecrets"
-version = "0.0.1"
+version = "0.0.2"
 description = "Tool to read the Docker Secrets"
 readme = "README.rst"
 authors = [{name = "csm", email = "cesarsanz.91@gmail.com"}]

--- a/tests/test_docker_secrets.py
+++ b/tests/test_docker_secrets.py
@@ -1,69 +1,102 @@
 import json
 import pytest
 from unittest.mock import patch, mock_open
-from docker_secrets import get_docket_secrets, load_all_secrets, load_selective_secrets
+from docker_secrets import get_docker_secrets, load_all_secrets, load_selective_secrets, _get_secrets_file
 import os
+
+@pytest.fixture(autouse=True)
+def cleanup_env_vars():
+    """Fixture to clean up environment variables after each test."""
+    # Store initial environment
+    initial_env = os.environ.copy()
+    
+    # Run the test
+    yield
+    
+    # Clean up any variables added during the test
+    current_env = os.environ.copy()
+    for key in current_env:
+        if key not in initial_env:
+            del os.environ[key]
+    
+    # Restore any variables that were changed
+    for key, value in initial_env.items():
+        os.environ[key] = value
+
+def test_get_secrets_file():
+    secrets = {"my_secret": "secret_value"}
+    secrets_json = json.dumps(secrets)
+
+    with patch("builtins.open", mock_open(read_data=secrets_json)):
+        with patch("os.path.isdir", return_value=False):
+            result = _get_secrets_file("/path/to/secrets.json")
+            assert result == secrets
+
+def test_get_secrets_file_directory():
+    secrets = {"my_secret": "secret_value"}
+    secrets_json = json.dumps(secrets)
+
+    with patch("builtins.open", mock_open(read_data=secrets_json)):
+        with patch("os.path.isdir", return_value=True):
+            with patch("os.listdir", return_value=["secrets.json"]):
+                result = _get_secrets_file("/path/to/secrets")
+                assert result == secrets
+
+def test_get_secrets_file_empty_directory():
+    with patch("os.path.isdir", return_value=True):
+        with patch("os.listdir", return_value=[]):
+            with pytest.raises(IOError):
+                _get_secrets_file("/path/to/empty/dir")
+
+def test_get_secrets_file_invalid_json():
+    invalid_json = "{invalid_json}"
+
+    with patch("builtins.open", mock_open(read_data=invalid_json)):
+        with patch("os.path.isdir", return_value=False):
+            with pytest.raises(ValueError):
+                _get_secrets_file("/path/to/invalid.json")
 
 def test_get_docker_secrets_valid():
     secret_name = "my_secret"
     secret_value = "secret_value"
     secrets = {secret_name: secret_value}
-    secrets_json = json.dumps(secrets)
 
-    with patch("builtins.open", mock_open(read_data=secrets_json)):
-        with patch("os.listdir", return_value=["secrets.json"]):
-            result = get_docket_secrets(secret_name)
-            assert result == secret_value
+    with patch("docker_secrets._get_secrets_file", return_value=secrets):
+        result = get_docker_secrets(secret_name)
+        assert result == secret_value
 
 def test_get_docker_secrets_missing_secret():
     secret_name = "missing_secret"
     secrets = {"my_secret": "secret_value"}
-    secrets_json = json.dumps(secrets)
 
-    with patch("builtins.open", mock_open(read_data=secrets_json)):
-        with patch("os.listdir", return_value=["secrets.json"]):
-            with pytest.raises(KeyError):
-                get_docket_secrets(secret_name)
-
-def test_get_docker_secrets_invalid_json():
-    invalid_json = "{invalid_json}"
-
-    with patch("builtins.open", mock_open(read_data=invalid_json)):
-        with patch("os.listdir", return_value=["secrets.json"]):
-            with pytest.raises(ValueError):
-                get_docket_secrets("my_secret")
+    with patch("docker_secrets._get_secrets_file", return_value=secrets):
+        with pytest.raises(KeyError):
+            get_docker_secrets(secret_name)
 
 def test_get_docker_secrets_io_error():
-    with patch("os.listdir", side_effect=IOError):
+    with patch("docker_secrets._get_secrets_file", side_effect=IOError("Test IO error")):
         with pytest.raises(IOError):
-            get_docket_secrets("my_secret")
-
-def test_get_docker_secrets_local_env():
-    secret_name = "my_secret"
-    secret_value = "secret_value"
-    secrets = {secret_name: secret_value}
-    secrets_json = json.dumps(secrets)
-
-    with patch.dict("os.environ", {"LOCAL_SECRETS": secrets_json}):
-        result = get_docket_secrets(secret_name)
-        assert result == secret_value
+            get_docker_secrets("my_secret")
 
 def test_load_all_secrets():
     secrets = {"my_secret": "secret_value", "another_secret": "another_value"}
-    secrets_json = json.dumps(secrets)
 
-    with patch("builtins.open", mock_open(read_data=secrets_json)):
-        with patch("os.listdir", return_value=["secrets.json"]):
-            load_all_secrets()
-            assert os.environ["my_secret"] == "secret_value"
-            assert os.environ["another_secret"] == "another_value"
+    with patch("docker_secrets._get_secrets_file", return_value=secrets):
+        load_all_secrets()
+        assert os.environ["my_secret"] == "secret_value"
+        assert os.environ["another_secret"] == "another_value"
 
 def test_load_selective_secrets():
     secrets = {"my_secret": "secret_value", "another_secret": "another_value"}
-    secrets_json = json.dumps(secrets)
 
-    with patch("builtins.open", mock_open(read_data=secrets_json)):
-        with patch("os.listdir", return_value=["secrets.json"]):
-            load_selective_secrets(["my_secret"])
-            assert os.environ["my_secret"] == "secret_value"
-            assert "another_secret" not in os.environ
+    with patch("docker_secrets._get_secrets_file", return_value=secrets):
+        load_selective_secrets(["my_secret"])
+        assert os.environ["my_secret"] == "secret_value"
+        assert "another_secret" not in os.environ
+
+def test_load_selective_secrets_missing():
+    secrets = {"my_secret": "secret_value"}
+
+    with patch("docker_secrets._get_secrets_file", return_value=secrets):
+        with pytest.raises(KeyError):
+            load_selective_secrets(["missing_secret"])

--- a/tests/test_docker_secrets.py
+++ b/tests/test_docker_secrets.py
@@ -1,7 +1,8 @@
 import json
 import pytest
 from unittest.mock import patch, mock_open
-from docker_secrets import get_docket_secrets
+from docker_secrets import get_docket_secrets, load_all_secrets, load_selective_secrets
+import os
 
 def test_get_docker_secrets_valid():
     secret_name = "my_secret"
@@ -46,3 +47,23 @@ def test_get_docker_secrets_local_env():
     with patch.dict("os.environ", {"LOCAL_SECRETS": secrets_json}):
         result = get_docket_secrets(secret_name)
         assert result == secret_value
+
+def test_load_all_secrets():
+    secrets = {"my_secret": "secret_value", "another_secret": "another_value"}
+    secrets_json = json.dumps(secrets)
+
+    with patch("builtins.open", mock_open(read_data=secrets_json)):
+        with patch("os.listdir", return_value=["secrets.json"]):
+            load_all_secrets()
+            assert os.environ["my_secret"] == "secret_value"
+            assert os.environ["another_secret"] == "another_value"
+
+def test_load_selective_secrets():
+    secrets = {"my_secret": "secret_value", "another_secret": "another_value"}
+    secrets_json = json.dumps(secrets)
+
+    with patch("builtins.open", mock_open(read_data=secrets_json)):
+        with patch("os.listdir", return_value=["secrets.json"]):
+            load_selective_secrets(["my_secret"])
+            assert os.environ["my_secret"] == "secret_value"
+            assert "another_secret" not in os.environ


### PR DESCRIPTION
Fixes #3

Add new functions to load secrets into environment variables.

* **docker_secrets.py**
  - Add `load_all_secrets` function to load all secrets into environment variables.
  - Add `load_selective_secrets` function to load selective secrets into environment variables.
  - Add typing hints to all functions.

* **README.rst**
  - Update usage instructions to include `load_all_secrets` and `load_selective_secrets` functions.

* **tests/test_docker_secrets.py**
  - Add tests for `load_all_secrets` function.
  - Add tests for `load_selective_secrets` function.

