### PR TITLE
Add an env variable to set the location of the secrets file

### DIFF
--- a/docker_secrets.py
+++ b/docker_secrets.py
@@ -14,7 +14,7 @@ def _get_secrets_file(secrets_path: str | None) -> dict[str, str]:
     """
 
     if secrets_path is None:
-        secrets_path = os.path.abspath(os.path.join(os.sep, "run", "secrets"))
+        secrets_path = os.getenv("SECRETS_PATH", os.path.abspath(os.path.join(os.sep, "run", "secrets")))
         
     try:
         if os.path.isdir(secrets_path):
@@ -57,7 +57,7 @@ def get_docker_secrets(
 
 
 def load_all_secrets(
-    secrets_path: str = os.path.abspath(os.path.join(os.sep, "run", "secrets")),
+    secrets_path: str = None,
 ) -> None:
     """This function loads all docker secrets into environment variables
 
@@ -73,7 +73,7 @@ def load_all_secrets(
 
 def load_selective_secrets(
     names: list[str],
-    secrets_path: str = os.path.abspath(os.path.join(os.sep, "run", "secrets")),
+    secrets_path: str = None,
 ) -> None:
     """This function loads selective docker secrets into environment variables
 


### PR DESCRIPTION
Fixes #6

Add support for `SECRETS_PATH` environment variable to set the location of the secrets file.

* Update `_get_secrets_file` function to use `SECRETS_PATH` environment variable if `secrets_path` is not provided.
* Modify `get_docker_secrets`, `load_all_secrets`, and `load_selective_secrets` functions to use `SECRETS_PATH` environment variable if `secrets_path` is not provided.
* Add tests for `SECRETS_PATH` environment variable in `test_get_secrets_file`, `test_get_docker_secrets_valid`, `test_load_all_secrets`, and `test_load_selective_secrets`.

